### PR TITLE
minor: sort the imported modules using isort

### DIFF
--- a/s3_account_search/cli.py
+++ b/s3_account_search/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 from argparse import ArgumentParser
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import boto3 as boto3
 from aws_assume_role_lib import assume_role


### PR DESCRIPTION
re-sort the imported modules using [Python isort](https://pycqa.github.io/isort/) so we can have a standardized format while importing modules.